### PR TITLE
放送一覧ページ、エンジビア投稿ページ、アーカイブページ（ユーザー）を作成

### DIFF
--- a/components/ArchiveIframe.tsx
+++ b/components/ArchiveIframe.tsx
@@ -8,8 +8,8 @@ const ArchiveIframe: VFC<Props> = (props) => {
   const { archiveURL } = props;
   return (
     <iframe
-      width="560"
-      height="315"
+      width="704"
+      height="395.92"
       src={archiveURL}
       title="YouTube video player"
       frameBorder="0"

--- a/components/ArchiveIframe.tsx
+++ b/components/ArchiveIframe.tsx
@@ -1,0 +1,22 @@
+import { VFC } from "react";
+
+type Props = {
+  archiveURL: string;
+};
+
+const ArchiveIframe: VFC<Props> = (props) => {
+  const { archiveURL } = props;
+  return (
+    <iframe
+      width="560"
+      height="315"
+      src={archiveURL}
+      title="YouTube video player"
+      frameBorder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+    ></iframe>
+  );
+};
+
+export default ArchiveIframe;

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -9,7 +9,7 @@ type Props = {
 const Avatar: VFC<Props> = (props) => {
   const { displayname, iconURL } = props;
   return (
-    <div className="flex justify-center items-center">
+    <div className="flex justify-center items-center text-sm">
       <div className="mr-3">
         <Image
           src={iconURL}
@@ -19,7 +19,7 @@ const Avatar: VFC<Props> = (props) => {
           className="rounded-full"
         />
       </div>
-      <h3 className="">{displayname}</h3>
+      <h3>{displayname}</h3>
     </div>
   );
 };

--- a/components/BroadcastItem.tsx
+++ b/components/BroadcastItem.tsx
@@ -1,6 +1,9 @@
-import { VFC } from "react";
+import { useRouter } from "next/dist/client/router";
+import { useCallback, VFC } from "react";
 import BroadcastStatus from "./BroadcastStatus";
+
 type Props = {
+  broadcastId: string;
   title: string;
   status: "before" | "during" | "after";
   engibeerCount: number;
@@ -8,9 +11,28 @@ type Props = {
 };
 
 const BroadcastItem: VFC<Props> = (props) => {
-  const { title, status, engibeerCount, date } = props;
+  const { broadcastId, title, status, engibeerCount, date } = props;
+  const router = useRouter();
+  const routerPush = useCallback(
+    (broadcastId: string, status: "before" | "during" | "after"): void => {
+      if (status === "before") {
+        // 放送前の場合 エンジビア投稿画面に遷移
+        router.push(`before/${broadcastId}/engibeer/add`);
+      } else if (status === "during") {
+        // 放送中の場合 放送中のページに遷移
+        router.push(`/live/${broadcastId}`);
+      } else {
+        // 放送済みの場合　アーカイブのページに遷移
+        router.push(`/archive/${broadcastId}`);
+      }
+    },
+    []
+  );
   return (
-    <div className="text-sm px-6 py-4 h-20 bg-white border-b cursor-pointer">
+    <div
+      className="text-sm px-6 py-4 h-20 bg-white border-b cursor-pointer"
+      onClick={() => routerPush(broadcastId, status)}
+    >
       <div className="flex justify-between mb-2">
         <h4 className="text-light_blue_600"> {title}</h4>
         <div className="">

--- a/components/BroadcastStatus.tsx
+++ b/components/BroadcastStatus.tsx
@@ -7,19 +7,19 @@ const BroadcastStatus: VFC<Props> = (props) => {
   const { status } = props;
   if (status === "before") {
     return (
-      <div className="bg-orange py-0.5 px-2.5 rounded-xl text-xs text-orange_800 text-center">
+      <div className="bg-orange py-0.5 px-2.5 rounded-xl text-sm text-orange_800 text-center">
         放送前・エンジビア募集中
       </div>
     );
   } else if (status === "during") {
     return (
-      <div className="bg-green-100  py-0.5 px-2.5 rounded-xl text-xs text-green-800 text-center">
+      <div className="bg-green-100  py-0.5 px-2.5 rounded-xl text-sm text-green-800 text-center">
         放送中
       </div>
     );
   } else {
     return (
-      <div className="bg-gray-200 py-0.5 px-2.5 rounded-xl text-xs text-gray-900 text-center">
+      <div className="bg-gray-200 py-0.5 px-2.5 rounded-xl text-sm text-gray-900 text-center">
         放送済み
       </div>
     );

--- a/components/BroadcastTitle.tsx
+++ b/components/BroadcastTitle.tsx
@@ -1,0 +1,21 @@
+import { VFC } from "react";
+import BroadcastStatus from "./BroadcastStatus";
+
+type Props = {
+  title: string;
+  status: "before" | "during" | "after";
+};
+
+const BroadcastTitle: VFC<Props> = (props) => {
+  const { title, status } = props;
+  return (
+    <div className='flex flex-col'>
+      <div className="mx-auto mb-4">
+        <BroadcastStatus status={status} />
+      </div>
+      <h1 className="text-gray-900 text-3xl text-center">{title}</h1>
+    </div>
+  );
+};
+
+export default BroadcastTitle;

--- a/components/HeyUserItem.tsx
+++ b/components/HeyUserItem.tsx
@@ -1,0 +1,22 @@
+import { VFC } from "react";
+import Avatar from "../components/Avatar";
+
+type Props = {
+  displayname: string;
+  iconURL: string;
+  heyCount: string;
+};
+
+const HeyUserItem: VFC<Props> = (props) => {
+  const { displayname, iconURL, heyCount } = props;
+  return (
+    <div className="flex items-center justify-between h-16 w-64  border-b">
+      <Avatar displayname={displayname} iconURL={iconURL} />
+      <div className=" text-gray-700 bg-white border rounded-xl px-2.5 py-px text-sm">
+        {heyCount}へぇ
+      </div>
+    </div>
+  );
+};
+
+export default HeyUserItem;

--- a/db.json
+++ b/db.json
@@ -1,22 +1,47 @@
 {
   "broadcasts": [
     {
+      "id": 1,
       "title": "第一回エンジビアの泉",
       "status": "after",
       "engibeerCount": 10,
       "date": "2021年7月12日"
     },
     {
+      "id": 2,
       "title": "第二回エンジビアの泉",
       "status": "during",
       "engibeerCount": 20,
       "date": "2021年7月12日"
     },
     {
+      "id": 3,
       "title": "第三回エンジビアの泉",
       "status": "before",
       "engibeerCount": 10,
       "date": "2021年7月12日"
+    }
+  ],
+  "HeyUser": [
+    {
+      "displayName": "ファンキー後藤",
+      "iconURL": "https://source.unsplash.com/random",
+      "heyCount": 18
+    },
+    {
+      "displayName": "マイケル竹田",
+      "iconURL": "https://source.unsplash.com/random",
+      "heyCount": 13
+    },
+    {
+      "displayName": "鈴木サンダー",
+      "iconURL": "https://source.unsplash.com/random",
+      "heyCount": 15
+    },
+    {
+      "displayName": "山田花子",
+      "iconURL": "https://source.unsplash.com/random",
+      "heyCount": 9
     }
   ]
 }

--- a/pages/archive/[broadcastId].tsx
+++ b/pages/archive/[broadcastId].tsx
@@ -1,0 +1,55 @@
+import { useRouter } from "next/dist/client/router";
+import { useCallback, useEffect, useState, VFC } from "react";
+import ArchiveIframe from "../../components/ArchiveIframe";
+import BroadcastTitle from "../../components/BroadcastTitle";
+
+type BroadcastInfo = {
+  id: string;
+  title: string;
+  status: "before" | "during" | "after";
+  engibeerCount: string;
+  date: string;
+};
+
+const ArchivePage: VFC = () => {
+  const [broadcastInfo, setBroadcastInfo] = useState<BroadcastInfo>();
+
+  const router = useRouter();
+
+  const fetchBroadcastInfo = useCallback(
+    async (broadcastId: string | string[] | undefined) => {
+      const res = await fetch(
+        `http://localhost:3001/broadcasts/${broadcastId}`
+      );
+      const json = await res.json();
+      setBroadcastInfo(json);
+    },[]
+  );
+
+  useEffect(() => {
+    // クエリがセットされたことを検知
+    if (router.asPath !== router.route) {
+      const { broadcastId } = router.query;
+      fetchBroadcastInfo(broadcastId);
+    }
+  }, [router]);
+  return (
+    <div className="flex flex-col justify-center items-center">
+      {broadcastInfo !== undefined ? (
+        <div className="pt-10 mb-8">
+          <BroadcastTitle
+            title={broadcastInfo.title}
+            status={broadcastInfo.status}
+          />
+        </div>
+      ) : null}
+
+      <div>
+        {/* アーカイブのURLを取得してArchivveIframeコンポーネントのarchiveURLに渡す必要がある */}
+        <ArchiveIframe archiveURL="https://www.youtube.com/embed/JkMWZeGnoD0" />
+      </div>
+    </div>
+  );
+};
+
+export default ArchivePage;

--- a/pages/before/[broadcastId]/engibeer/add.tsx
+++ b/pages/before/[broadcastId]/engibeer/add.tsx
@@ -1,0 +1,68 @@
+import { useRouter } from "next/dist/client/router";
+import { useCallback, useEffect, useState, VFC } from "react";
+import BroadcastTitle from "../../../../components/BroadcastTitle";
+import { Button } from "../../../../components/Button";
+
+type BroadcastInfo = {
+  id: string;
+  title: string;
+  status: "before" | "during" | "after";
+  engibeerCount: string;
+  date: string;
+};
+
+const EngiberrAddPage: VFC = () => {
+  const [broadcastInfo, setBroadcastInfo] = useState<BroadcastInfo>();
+  const [engibeer, setEngibeer] = useState("");
+
+  const router = useRouter();
+
+  const fetchLiveInfo = useCallback(
+    async (broadcastId: string | string[] | undefined) => {
+      const res = await fetch(
+        `http://localhost:3001/broadcasts/${broadcastId}`
+      );
+      const json = await res.json();
+      setBroadcastInfo(json);
+    },
+    []
+  );
+
+  const saveEngibeer = useCallback(() => {
+    // エンジビアを保存する処理を書く
+    console.log(engibeer);
+  }, [engibeer]);
+
+  useEffect(() => {
+    // クエリがセットされたことを検知
+    if (router.asPath !== router.route) {
+      const { broadcastId } = router.query;
+      fetchLiveInfo(broadcastId);
+    }
+  }, [router]);
+
+  return (
+    <div className="flex flex-col justify-center items-center">
+      {broadcastInfo !== undefined ? (
+        <div className="pt-10 mb-8">
+          <BroadcastTitle
+            title={broadcastInfo.title}
+            status={broadcastInfo.status}
+          />
+        </div>
+      ) : null}
+
+      <textarea
+        className="w-2/4 h-24 px-3.5 py-3 text-2xl mb-8 font-bold"
+        cols={30}
+        rows={10}
+        placeholder="エンジビアを入力する"
+        onChange={(e) => setEngibeer(e.target.value)}
+      ></textarea>
+
+      <Button text="保存する" onClick={saveEngibeer} />
+    </div>
+  );
+};
+
+export default EngiberrAddPage;

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,20 +1,21 @@
-import { useEffect, useState, VFC } from "react";
+import { useCallback, useEffect, useState, VFC } from "react";
 import BroadcastItem from "../components/BroadcastItem";
 
 type Broadcast = {
+  id: string;
   title: string;
   status: "before" | "during" | "after";
   engibeerCount: number;
   date: string;
 };
-const Live: VFC = () => {
+const HomePage: VFC = () => {
   const [broadcastList, setBroadcastList] = useState<Array<Broadcast>>([]);
 
-  const fetchBroadcast = async () => {
+  const fetchBroadcast = useCallback(async () => {
     const res = await fetch("http://localhost:3001/broadcasts");
     const json = await res.json();
     setBroadcastList(json);
-  };
+  }, []);
 
   useEffect(() => {
     fetchBroadcast();
@@ -28,6 +29,7 @@ const Live: VFC = () => {
           return (
             <div key={index} className="first:border">
               <BroadcastItem
+                broadcastId={item.id}
                 title={item.title}
                 date={item.date}
                 status={item.status}
@@ -41,4 +43,4 @@ const Live: VFC = () => {
   );
 };
 
-export default Live;
+export default HomePage;

--- a/pages/live/[broadcastId].tsx
+++ b/pages/live/[broadcastId].tsx
@@ -1,0 +1,91 @@
+import { useRouter } from "next/dist/client/router";
+import { useCallback, useEffect, useState, VFC } from "react";
+import BroadcastTitle from "../../components/BroadcastTitle";
+import HeyButton from "../../components/HeyButton";
+import HeyUserItem from "../../components/HeyUserItem";
+
+type LiveInfo = {
+  id: string;
+  title: string;
+  status: "before" | "during" | "after";
+  engibeerCount: string;
+  date: string;
+};
+
+type HeyUser = {
+  displayName: string;
+  iconURL: string;
+  heyCount: string;
+};
+
+const LivePage: VFC = () => {
+  const [broadcastInfo, setBroadcastInfo] = useState<LiveInfo>();
+  const [heyUserList, setHeyUserList] = useState<Array<HeyUser>>([]);
+  const [heyCount, setHeyCount] = useState(0);
+
+  const router = useRouter();
+
+  const fetchBroadcastInfo = useCallback(
+    async (broadcastId: string | string[] | undefined) => {
+      const res = await fetch(
+        `http://localhost:3001/broadcasts/${broadcastId}`
+      );
+      const json = await res.json();
+      setBroadcastInfo(json);
+    },
+    []
+  );
+
+  const fetchHeyUser = useCallback(async () => {
+    const res = await fetch("http://localhost:3001/heyUser");
+    const json = await res.json();
+    setHeyUserList(json);
+  }, []);
+
+  useEffect(() => {
+    // クエリがセットされたことを検知
+    if (router.asPath !== router.route) {
+      const { broadcastId } = router.query;
+      fetchBroadcastInfo(broadcastId);
+    }
+    fetchHeyUser();
+  }, [router]);
+  return (
+    <>
+      {broadcastInfo !== undefined ? (
+        <div className="pt-10">
+          <BroadcastTitle
+            title={broadcastInfo.title}
+            status={broadcastInfo.status}
+          />
+        </div>
+      ) : null}
+
+      <div className="absolute top-16 right-6">
+        {heyUserList.map((item: HeyUser, index: number) => {
+          return (
+            <div key={index}>
+              <HeyUserItem
+                displayname={item.displayName}
+                iconURL={item.iconURL}
+                heyCount={item.heyCount}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mb-auto">
+        <p className="text-3xl bg-white p-8 rounded-lg w-2/4 text-center mx-auto mt-8">
+          次のエンジビアをお待ちください
+        </p>
+      </div>
+
+      <div className="absolute left-2/4 transform -translate-x-1/2 top-2/3">
+        <HeyButton incrementHey={setHeyCount} />
+      </div>
+    </>
+  );
+};
+
+export default LivePage;


### PR DESCRIPTION
### Issue
#45 

### 主にやったこと

https://user-images.githubusercontent.com/74395986/142722597-69322a23-ec5e-4834-980f-07a859770650.mov



### pagesの構成を変更
- /home => 放送一覧ページ
- /before/放送ID/engibeer/add => エンジビア投稿ページ
- live/放送ID => ライブ中の放送ページ
- archive/放送ID => アーカイブページ

### コンポーネントの作成

- ArchiveIframeコンポーネントの作成 　　アーカイブの動画を埋め込むコンポーネント（Desktop-19で使われている）
- HeyUserItemコンポーネントの作成　　　へぇを押したユーザーとそのユーザーがおしたヘェ数を表示するコンポーネント（Desktop-13,18で使われている）
- BroadcastTitleコンポーネントの作成        放送のタイトルと状態を表示するコンポーネント（Desktop-13,15などで使われている）

### コンポーネントの修正
スタイルの変更など
